### PR TITLE
Build with Maven, inserting version into plugin.yml. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Eclipse stuff:
+.project
+.settings
+.classpath
+
+# Build:
+/classes/
+target/

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 main: com.rifledluffy.chairs.RFChairs
 name: RFChairs
-version: 6.0
+version: ${project.version}
 authors: [Rifle D. Luffy, VicenteRD, carlpoole, i0xHeX]
 api-version: 1.13
 description: Chairs but Rifle's way.

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.rifledluffy</groupId>
 	<artifactId>RiflesChairs</artifactId>
-	<version>6.0-SNAPSHOT</version>
+	<version>6.0.1</version>
 
 	<description>Chairs, but Rifle's way..</description>
 	<url>https://github.com/RifleDLuffy/RFChairs</url>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>com.rifledluffy</groupId>
+	<artifactId>RiflesChairs</artifactId>
+	<version>6.0-SNAPSHOT</version>
+
+	<description>Chairs, but Rifle's way..</description>
+	<url>https://github.com/RifleDLuffy/RFChairs</url>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>spigot-repo</id>
+			<url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+		</repository>
+		<repository>
+			<id>sk89q-repo</id>
+			<url>http://maven.sk89q.com/repo/</url>
+		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+	</repositories>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.spigotmc</groupId>
+			<artifactId>spigot-api</artifactId>
+			<version>1.13.2-R0.1-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.sk89q.worldguard</groupId>
+			<artifactId>worldguard-bukkit</artifactId>
+			<version>7.0.0</version>
+			<type>jar</type>
+		</dependency>
+		<dependency>
+			<groupId>com.github.IntellectualSites</groupId>
+			<artifactId>PlotSquared</artifactId>
+			<version>23b88a375da7587175c6662bdd3d9d96e7fe7060</version>
+		</dependency>
+		<dependency>
+			<groupId>com.github.TechFortress</groupId>
+			<artifactId>GriefPrevention</artifactId>
+			<version>16.12.alpha</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<defaultGoal>clean package</defaultGoal>
+		<sourceDirectory>${basedir}/src</sourceDirectory>
+		<resources>
+			<resource>
+				<targetPath>.</targetPath>
+				<filtering>true</filtering>
+				<directory>${basedir}</directory>
+				<includes>
+					<include>plugin.yml</include>
+					<include>config.yml</include>
+				</includes>
+			</resource>
+		</resources>
+	</build>
+</project>

--- a/src/com/rifledluffy/chairs/managers/WorldGuardManager.java
+++ b/src/com/rifledluffy/chairs/managers/WorldGuardManager.java
@@ -1,86 +1,77 @@
 package com.rifledluffy.chairs.managers;
 
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.Plugin;
+
 import com.rifledluffy.chairs.RFChairs;
 import com.rifledluffy.chairs.chairs.Chair;
-import com.rifledluffy.chairs.utility.Util;
-import com.sk89q.worldedit.math.BlockVector3;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.LocalPlayer;
 import com.sk89q.worldguard.WorldGuard;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.ApplicableRegionSet;
-import com.sk89q.worldguard.protection.flags.Flag;
 import com.sk89q.worldguard.protection.flags.StateFlag;
 import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
 import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
+import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.RegionContainer;
-import org.bukkit.entity.Player;
-import org.bukkit.plugin.Plugin;
-
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public class WorldGuardManager {
 
-	private RFChairs plugin = RFChairs.getInstance();
-	public WorldGuard worldGuard;
-	public WorldGuardPlugin worldGuardPlugin;
-	public RegionContainer container;
-	@SuppressWarnings("rawtypes")
-	public static Flag flag;
+    private RFChairs plugin = RFChairs.getInstance();
+    public WorldGuard worldGuard;
+    public WorldGuardPlugin worldGuardPlugin;
+    public RegionContainer container;
+    public static StateFlag flag;
 
-	public WorldGuardManager() {}
-	
-	public void setup() {
-		worldGuard = WorldGuard.getInstance();
-	}
-	
-	public void register() {
-		flag = new StateFlag("allow-seating", true);
-		FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
-	    try {
-	        registry.register(flag);
-	        plugin.log("Custom Flag Registered!");
-	    } catch (FlagConflictException e) {
-	    	plugin.log("Unable to register custom worldguard flag!");
-	    }
-	}
-	
-	public WorldGuardPlugin getWorldGuard() {
-		Plugin plugin = this.plugin.getServer().getPluginManager().getPlugin("WorldGuard");
-		
-		if (!(plugin instanceof WorldGuardPlugin)) return null;
-		return (WorldGuardPlugin) plugin;
-	}
-	
-	public boolean validateSeating(Chair chair, Player player) {
-		double xPos = chair.getLocation().getX();
-		double yPos = chair.getLocation().getY();
-		double zPos = chair.getLocation().getZ();
+    public WorldGuardManager() {
+    }
 
-		WorldGuardManager worldManager = plugin.getWorldGuardManager();
+    public void setup() {
+        worldGuard = WorldGuard.getInstance();
+    }
 
-		LocalPlayer localPlayer = worldManager.getWorldGuard().wrapPlayer(player);
+    public void register() {
+        flag = new StateFlag("allow-seating", true);
+        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+        try {
+            registry.register(flag);
+            plugin.log("Custom Flag Registered!");
+        } catch (FlagConflictException e) {
+            plugin.log("Unable to register custom worldguard flag!");
+        }
+    }
 
-        BlockVector3 vector3 = BlockVector3.at(xPos, yPos, zPos);
+    public WorldGuardPlugin getWorldGuard() {
+        Plugin plugin = this.plugin.getServer().getPluginManager().getPlugin("WorldGuard");
 
-        List<ApplicableRegionSet> regionSetList = getContainer().getLoaded().stream()
-                .map(manager -> manager.getApplicableRegions(vector3))
-                .collect(Collectors.toList());
+        if (!(plugin instanceof WorldGuardPlugin)) {
+            return null;
+        }
+        return (WorldGuardPlugin) plugin;
+    }
 
-        if (regionSetList.size() == 0) return true;
+    public boolean validateSeating(Chair chair, Player player) {
+        RegionContainer container = getContainer();
+        Location loc = chair.getLocation();
+        RegionManager regionManager = container.get(BukkitAdapter.adapt(loc.getWorld()));
+        if (regionManager != null) {
+            com.sk89q.worldedit.util.Location weLoc = BukkitAdapter.adapt(loc);
+            LocalPlayer wgPlayer = getWorldGuard().wrapPlayer(player);
+            ApplicableRegionSet applicableRegions = regionManager.getApplicableRegions(weLoc.toVector().toBlockPoint());
+            return applicableRegions.testState(wgPlayer, getFlag());
+        } else {
+            return true;
+        }
+    }
 
-        return regionSetList.stream()
-                .allMatch(set -> set.testState(localPlayer, (StateFlag) worldManager.getFlag()));
-	}
+    public RegionContainer getContainer() {
+        return worldGuard.getPlatform().getRegionContainer();
+    }
 
-	public RegionContainer getContainer() {
-		return worldGuard.getPlatform().getRegionContainer();
-	}
-	
-	public Flag<?> getFlag() {
-		return flag;
-	}
+    public StateFlag getFlag() {
+        return flag;
+    }
 
 }

--- a/src/com/rifledluffy/chairs/utility/Util.java
+++ b/src/com/rifledluffy/chairs/utility/Util.java
@@ -119,10 +119,14 @@ public class Util {
 				&& !validExit(block.getRelative(BlockFace.SOUTH))
 				&& !validExit(block.getRelative(BlockFace.WEST));
 	}
-	
+
+	private static boolean isAir(Material type) {
+		return type == Material.AIR || type == Material.CAVE_AIR || type == Material.VOID_AIR;
+	}
+
 	private static boolean validExit(Block block) {
 		Material type = block.getType();
-		return type == Material.AIR || type.name().equals("WALL_SIGN") || type.name().endsWith("_WALL_SIGN");
+		return isAir(type) || type.name().equals("WALL_SIGN") || type.name().endsWith("_WALL_SIGN");
 	}
 	
 	public static boolean isLiqiudOrMagma(Block block) {
@@ -144,7 +148,7 @@ public class Util {
 		BlockFace side = faces.get(0);
 		BlockFace otherSide = faces.get(1);
 
-		if (block.getRelative(BlockFace.UP).getType() != Material.AIR) return false;
+		if (!isAir(block.getRelative(BlockFace.UP).getType())) return false;
 		
 		if (validatedChair(block.getRelative(side))) if (validSeat(block.getRelative(side), side, block)) validSides++;
 		if (validatedChair(block.getRelative(otherSide))) if (validSeat(block.getRelative(otherSide), otherSide, block)) validSides++;
@@ -288,11 +292,11 @@ public class Util {
 	}
 	
 	public static boolean canFitPlayer(Block block) {
-		return block.getType() == Material.AIR && block.getRelative(BlockFace.UP).getType() == Material.AIR;
+		return isAir(block.getType()) && isAir(block.getRelative(BlockFace.UP).getType());
 	}
 	
 	public static boolean safePlace(Block block) {
-		return block.getRelative(BlockFace.DOWN).getType() != Material.AIR;
+		return isAir(block.getRelative(BlockFace.DOWN).getType());
 	}
 	
 	public static Vector getVectorDir(Location caster, Location target) {


### PR DESCRIPTION
This pull request builds the plugin JAR with one command, `mvn`. You need only edit the version number in one file (`pom.xml`) to set the version number on the JAR file and in `plugin.yml`.

If including the version number in the filename is not to your liking, I can talk you through the Maven syntax to drop the version number from the JAR file name. And I made this commit a while back when I was trying to get i0xHeX's fork built in a hurry. Consequently the version in `pom.xml` is `6.0-SNAPSHOT` which I guess you would want to change anyway before you merge.

The default goal when you run `mvn` is set to `clean package`, which builds the JAR. If you prefer, you can change the default goal to `clean install` to put the JAR in the local Maven repository.

This PR also includes a `.gitignore` file to avoid checking in build artifacts.